### PR TITLE
Refined package.json for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "rerum_server_nodejs",
   "type": "module",
-  "version": "0.0.0",
-  "main": "./app.js",
-  "description": "Rerum API server for database access.",
+  "version": "1.0.0",
+  "main": "index.js",
+  "description": "Rerum API v1 server for storing and querying JSON-LD objects, annotations, and IIIF data.",
+  "bin": {
+    "rerum_server_nodejs": "./bin/rerum_v1.js"
+  },
   "keywords": [
     "rerum",
+    "api",
+    "jsonld",
     "annotation",
     "iiif",
     "repository",
@@ -16,7 +21,7 @@
     "mongodb"
   ],
   "homepage": "https://store.rerum.io",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "author": "Research Computing Group <research.computing@slu.edu> (https://slu.edu)",
   "repository": {
       "type": "git",
@@ -29,7 +34,6 @@
     "node": ">=24.12.0",
     "npm": ">=11.7.0"
   },
-  "main": "index.js",
   "scripts": {
     "start": "node ./bin/rerum_v1.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",


### PR DESCRIPTION
Worked on #58 to refine package.json for npm publishing. Set the version to 1.0.0 and license to MIT, included a bin field and updated description and keywords. `npm pack` output produces a tarball, and the content produced includes expected sources and metadata files.