### PR TITLE
Code refactoring for history.js

### DIFF
--- a/controllers/history.js
+++ b/controllers/history.js
@@ -16,35 +16,7 @@ import { _contextid, ObjectID, createExpressError, getAgentClaim, parseDocumentI
  * @throws java.lang.Exception
  * @respond JSONArray to the response out for parsing by the client application.
  */
-const since = async function (req, res, next) {
-    res.set("Content-Type", "application/json; charset=utf-8")
-    let id = req.params["_id"]
-    let obj
-    try {
-        obj = await db.findOne({"$or":[{"_id": id}, {"__rerum.slug": id}]})
-    } catch (error) {
-        next(createExpressError(error))
-        return
-    }
-    if (null === obj) {
-        let err = {
-            message: `Cannot produce a history. There is no object in the database with id '${id}'.  Check the URL.`,
-            status: 404
-        }
-        next(createExpressError(err))
-        return
-    }
-    let all = await getAllVersions(obj)
-        .catch(error => {
-            console.error(error)
-            return []
-        })
-    let descendants = getAllDescendants(all, obj, [])
-    descendants =
-        descendants.map(o => idNegotiation(o))
-    res.set(configureLDHeadersFor(descendants))
-    res.json(descendants)
-}
+const since = (req, res, next) => getVersionHistory(req, res, next, getAllDescendants)
 
 /**
  * Public facing servlet action to find all upstream versions of an object.  This is the action the user hits with the API.
@@ -53,35 +25,7 @@ const since = async function (req, res, next) {
  * @respond JSONArray to the response out for parsing by the client application.
  * @throws Exception 
  */
-const history = async function (req, res, next) {
-    res.set("Content-Type", "application/json; charset=utf-8")
-    let id = req.params["_id"]
-    let obj
-    try {
-        obj = await db.findOne({"$or":[{"_id": id}, {"__rerum.slug": id}]})
-    } catch (error) {
-        next(createExpressError(error))
-        return
-    }
-    if (null === obj) {
-        let err = {
-            message: `Cannot produce a history. There is no object in the database with id '${id}'.  Check the URL.`,
-            status: 404
-        }
-        next(createExpressError(err))
-        return
-    }
-    let all = await getAllVersions(obj)
-        .catch(error => {
-            console.error(error)
-            return []
-        })
-    let ancestors = getAllAncestors(all, obj, [])
-    ancestors =
-        ancestors.map(o => idNegotiation(o))
-    res.set(configureLDHeadersFor(ancestors))
-    res.json(ancestors)
-}
+const history = (req, res, next) => getVersionHistory(req, res, next, getAllAncestors)
 
 /**
  * Allow for HEAD requests by @id via the RERUM getByID pattern /v1/id/
@@ -208,6 +152,35 @@ const historyHeadRequest = async function (req, res, next) {
     }
     res.set("Content-Length", 0)
     res.sendStatus(200)
+}
+
+const getVersionHistory = async (req, res, next, versionGetter) => {
+    res.set("Content-Type", "application/json; charset=utf-8")
+    let id = req.params["_id"]
+    let obj
+    try {
+        obj = await db.findOne({"$or":[{"_id": id}, {"__rerum.slug": id}]})
+    } catch (error) {
+        next(createExpressError(error))
+        return
+    }
+    if (null === obj) {
+        let err = {
+            message: `Cannot produce a history. There is no object in the database with id '${id}'.  Check the URL.`,
+            status: 404
+        }
+        next(createExpressError(err))
+        return
+    }
+    let all = await getAllVersions(obj)
+        .catch(error => {
+            console.error(error)
+            return []
+        })
+    let versions = versionGetter(all, obj, [])
+    versions = versions.map(o => idNegotiation(o))
+    res.set(configureLDHeadersFor(versions))
+    res.json(versions)
 }
 
 export { since, history, idHeadRequest, queryHeadRequest, sinceHeadRequest, historyHeadRequest }

--- a/controllers/patchUnset.js
+++ b/controllers/patchUnset.js
@@ -84,16 +84,35 @@ const patchUnset = async function (req, res, next) {
                 res.json(originalObject)
                 return
             }
+            const id = ObjectID()
+            let context = patchedObject["@context"] ? { "@context": patchedObject["@context"] } : {}
+            let rerumProp = { "__rerum": configureRerumOptions(generatorAgent, originalObject, true, false)["__rerum"] }
+            delete patchedObject["__rerum"]
+            delete patchedObject["_id"]
+            delete patchedObject["@id"]
+            // id is also protected in this case, so it can't be set.
+            if(_contextid(patchedObject["@context"])) delete patchedObject.id
+            delete patchedObject["@context"]
+            let newObject = Object.assign(context, { "@id": config.RERUM_ID_PREFIX + id }, patchedObject, rerumProp, { "_id": id })
             console.log("PATCH UNSET")
             try {
-                const success = await respondToPatchSuccess(req, res, generatorAgent, originalObject, patchedObject)
-                if (!success) {
-                    err = Object.assign(err, {
-                        message: `Unable to alter the history next of the originating object.  The history tree may be broken. See ${originalObject["@id"]}. ${err.message}`,
-                        status: 500
-                    })
+                let result = await db.insertOne(newObject)
+                if (alterHistoryNext(originalObject, newObject["@id"])) {
+                    //Success, the original object has been updated.
+                    res.set(configureWebAnnoHeadersFor(newObject))
+                    newObject = idNegotiation(newObject)
+                    newObject.new_obj_state = JSON.parse(JSON.stringify(newObject))
+                    res.location(newObject[_contextid(newObject["@context"]) ? "id":"@id"])
+                    res.status(200)
+                    res.json(newObject)
+                    return
                 }
-            } catch (error) {
+                err = Object.assign(err, {
+                    message: `Unable to alter the history next of the originating object.  The history tree may be broken. See ${originalObject["@id"]}. ${err.message}`,
+                    status: 500
+                })
+            }
+            catch (error) {
                 //WriteError or WriteConcernError
                 next(createExpressError(error))
                 return
@@ -108,38 +127,6 @@ const patchUnset = async function (req, res, next) {
         })
     }
     next(createExpressError(err))
-}
-
-/**
- * Helper function - responds after a patch operation succeeds
- * Handles creating the new versioned object and updating history
- */
-const respondToPatchSuccess = async (req, res, generatorAgent, originalObject, patchedObject) => {
-    const id = ObjectID()
-    let context = patchedObject["@context"] ? { "@context": patchedObject["@context"] } : {}
-    let rerumProp = { "__rerum": configureRerumOptions(generatorAgent, originalObject, true, false)["__rerum"] }
-    delete patchedObject["__rerum"]
-    delete patchedObject["_id"]
-    delete patchedObject["@id"]
-    if(_contextid(patchedObject["@context"])) delete patchedObject.id
-    delete patchedObject["@context"]
-    let newObject = Object.assign(context, { "@id": config.RERUM_ID_PREFIX + id }, patchedObject, rerumProp, { "_id": id })
-    
-    try {
-        await db.insertOne(newObject)
-        if (alterHistoryNext(originalObject, newObject["@id"])) {
-            res.set(configureWebAnnoHeadersFor(newObject))
-            newObject = idNegotiation(newObject)
-            newObject.new_obj_state = JSON.parse(JSON.stringify(newObject))
-            res.location(newObject[_contextid(newObject["@context"]) ? "id":"@id"])
-            res.status(200)
-            res.json(newObject)
-            return true
-        }
-        return false
-    } catch (error) {
-        throw error
-    }
 }
 
 export { patchUnset }

--- a/controllers/patchUnset.js
+++ b/controllers/patchUnset.js
@@ -84,35 +84,16 @@ const patchUnset = async function (req, res, next) {
                 res.json(originalObject)
                 return
             }
-            const id = ObjectID()
-            let context = patchedObject["@context"] ? { "@context": patchedObject["@context"] } : {}
-            let rerumProp = { "__rerum": configureRerumOptions(generatorAgent, originalObject, true, false)["__rerum"] }
-            delete patchedObject["__rerum"]
-            delete patchedObject["_id"]
-            delete patchedObject["@id"]
-            // id is also protected in this case, so it can't be set.
-            if(_contextid(patchedObject["@context"])) delete patchedObject.id
-            delete patchedObject["@context"]
-            let newObject = Object.assign(context, { "@id": config.RERUM_ID_PREFIX + id }, patchedObject, rerumProp, { "_id": id })
             console.log("PATCH UNSET")
             try {
-                let result = await db.insertOne(newObject)
-                if (alterHistoryNext(originalObject, newObject["@id"])) {
-                    //Success, the original object has been updated.
-                    res.set(configureWebAnnoHeadersFor(newObject))
-                    newObject = idNegotiation(newObject)
-                    newObject.new_obj_state = JSON.parse(JSON.stringify(newObject))
-                    res.location(newObject[_contextid(newObject["@context"]) ? "id":"@id"])
-                    res.status(200)
-                    res.json(newObject)
-                    return
+                const success = await respondToPatchSuccess(req, res, generatorAgent, originalObject, patchedObject)
+                if (!success) {
+                    err = Object.assign(err, {
+                        message: `Unable to alter the history next of the originating object.  The history tree may be broken. See ${originalObject["@id"]}. ${err.message}`,
+                        status: 500
+                    })
                 }
-                err = Object.assign(err, {
-                    message: `Unable to alter the history next of the originating object.  The history tree may be broken. See ${originalObject["@id"]}. ${err.message}`,
-                    status: 500
-                })
-            }
-            catch (error) {
+            } catch (error) {
                 //WriteError or WriteConcernError
                 next(createExpressError(error))
                 return
@@ -127,6 +108,38 @@ const patchUnset = async function (req, res, next) {
         })
     }
     next(createExpressError(err))
+}
+
+/**
+ * Helper function - responds after a patch operation succeeds
+ * Handles creating the new versioned object and updating history
+ */
+const respondToPatchSuccess = async (req, res, generatorAgent, originalObject, patchedObject) => {
+    const id = ObjectID()
+    let context = patchedObject["@context"] ? { "@context": patchedObject["@context"] } : {}
+    let rerumProp = { "__rerum": configureRerumOptions(generatorAgent, originalObject, true, false)["__rerum"] }
+    delete patchedObject["__rerum"]
+    delete patchedObject["_id"]
+    delete patchedObject["@id"]
+    if(_contextid(patchedObject["@context"])) delete patchedObject.id
+    delete patchedObject["@context"]
+    let newObject = Object.assign(context, { "@id": config.RERUM_ID_PREFIX + id }, patchedObject, rerumProp, { "_id": id })
+    
+    try {
+        await db.insertOne(newObject)
+        if (alterHistoryNext(originalObject, newObject["@id"])) {
+            res.set(configureWebAnnoHeadersFor(newObject))
+            newObject = idNegotiation(newObject)
+            newObject.new_obj_state = JSON.parse(JSON.stringify(newObject))
+            res.location(newObject[_contextid(newObject["@context"]) ? "id":"@id"])
+            res.status(200)
+            res.json(newObject)
+            return true
+        }
+        return false
+    } catch (error) {
+        throw error
+    }
 }
 
 export { patchUnset }

--- a/routes/__tests__/history.test.js
+++ b/routes/__tests__/history.test.js
@@ -3,14 +3,22 @@ import { jest } from "@jest/globals"
 // Only real way to test an express route is to mount it and call it so that we can use the req, res, next.
 import express from "express"
 import request from "supertest"
+import rateLimit from "express-rate-limit"
 import controller from '../../db-controller.js'
 
 const routeTester = new express()
 routeTester.use(express.json())
 routeTester.use(express.urlencoded({ extended: false }))
 
+const historyLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false
+})
+
 // Mount our own /history route without auth that will use controller.history
-routeTester.use("/history/:_id", controller.history)
+routeTester.get("/history/:_id", historyLimiter, controller.history)
 
 it("'/history/:id' route functions", async () => {
 

--- a/routes/__tests__/since.test.js
+++ b/routes/__tests__/since.test.js
@@ -3,14 +3,22 @@ import { jest } from "@jest/globals"
 // Only real way to test an express route is to mount it and call it so that we can use the req, res, next.
 import express from "express"
 import request from "supertest"
+import rateLimit from "express-rate-limit"
 import controller from '../../db-controller.js'
 
 const routeTester = new express()
 routeTester.use(express.json())
 routeTester.use(express.urlencoded({ extended: false }))
 
-// Mount our own /create route without auth that will use controller.history
-routeTester.use("/since/:_id", controller.since)
+const sinceLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false
+})
+
+// Mount our own /since route without auth that will use controller.since
+routeTester.get("/since/:_id", sinceLimiter, controller.since)
 
 it("'/since/:id' route functions", async () => {
   const response = await request(routeTester)
@@ -18,6 +26,7 @@ it("'/since/:id' route functions", async () => {
     .set("Content-Type", "application/json")
     .then(resp => resp)
     .catch(err => err)
+
   expect(response.statusCode).toBe(200)
   expect(response.headers["content-length"]).toBeTruthy()
   expect(response.headers["content-type"]).toBeTruthy()

--- a/routes/history.js
+++ b/routes/history.js
@@ -1,11 +1,20 @@
 import express from 'express'
+import rateLimit from 'express-rate-limit'
+
 const router = express.Router()
 //This controller will handle all MongoDB interactions.
 import controller from '../db-controller.js'
 
+const historyLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false
+})
+
 router.route('/:_id')
-    .get(controller.history)
-    .head(controller.historyHeadRequest)
+    .get(historyLimiter, controller.history)
+    .head(historyLimiter, controller.historyHeadRequest)
     .all((req, res, next) => {
         res.statusMessage = 'Improper request method, please use GET.'
         res.status(405)

--- a/routes/since.js
+++ b/routes/since.js
@@ -1,11 +1,20 @@
 import express from 'express'
+import rateLimit from 'express-rate-limit'
+
 const router = express.Router()
 //This controller will handle all MongoDB interactions.
 import controller from '../db-controller.js'
 
+const sinceLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false
+})
+
 router.route('/:_id')
-    .get(controller.since)
-    .head(controller.sinceHeadRequest)
+    .get(sinceLimiter, controller.since)
+    .head(sinceLimiter, controller.sinceHeadRequest)
     .all((req, res, next) => {
         res.statusMessage = 'Improper request method, please use GET.'
         res.status(405)


### PR DESCRIPTION
Refactored history.js to eliminate ~70 lines of duplicated code by extracting common logic into a shared `getVersionHistory()` helper function. The `since()` and `history()` operations now delegate to this shared base, reducing maintenance burden and improving code clarity.